### PR TITLE
Alerts

### DIFF
--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/GroupsController.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/GroupsController.cs
@@ -37,8 +37,12 @@ namespace MyToolsYourToolsBackend.API.Controllers
         [HttpPost("groups")]
         public IActionResult AddGroup([FromBody]GroupForCreationDto groupFromBody)
         {
-            var groupToReturn = _groupService.AddGroup(groupFromBody);
+            if (_groupService.checkIfNameIsUnique(groupFromBody))
+            {
+                return BadRequest("Grupa o podanej nazwie już istnieje. Podaj inną nazwę.");
+            }
 
+            var groupToReturn = _groupService.AddGroup(groupFromBody);
             return Created(nameof(GetGroups), groupToReturn);
         }
     }

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/GroupsController.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/GroupsController.cs
@@ -37,7 +37,7 @@ namespace MyToolsYourToolsBackend.API.Controllers
         [HttpPost("groups")]
         public IActionResult AddGroup([FromBody]GroupForCreationDto groupFromBody)
         {
-            if (_groupService.checkIfNameIsUnique(groupFromBody))
+            if (_groupService.checkIfNameAlreadyExists(groupFromBody))
             {
                 return BadRequest("Grupa o podanej nazwie już istnieje. Podaj inną nazwę.");
             }

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Dtos/GroupForCreationDto.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Dtos/GroupForCreationDto.cs
@@ -2,11 +2,13 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.ComponentModel.DataAnnotations;
 
 namespace MyToolsYourToolsBackend.Application.Dtos
 {
     public class GroupForCreationDto
     {
+        [Required(AllowEmptyStrings = false, ErrorMessage = "Podaj nazwę grupy.")]
         public string Name { get; set; }
     }
 }

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/GroupService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/GroupService.cs
@@ -17,6 +17,12 @@ namespace MyToolsYourToolsBackend.Application.Services
         {
             _dbContext = dbContext;
         }
+
+        public bool checkIfNameIsUnique(GroupForCreationDto group)
+        {
+            return _dbContext.Groups.Any(g => g.Name == group.Name);
+        }
+
         public GroupDto AddGroup(GroupForCreationDto group)
         {
             var groupToSave = Mapper.Map<Group>(group);

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/GroupService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/GroupService.cs
@@ -18,7 +18,7 @@ namespace MyToolsYourToolsBackend.Application.Services
             _dbContext = dbContext;
         }
 
-        public bool checkIfNameIsUnique(GroupForCreationDto group)
+        public bool checkIfNameAlreadyExists(GroupForCreationDto group)
         {
             return _dbContext.Groups.Any(g => g.Name == group.Name);
         }

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/IGroupService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/IGroupService.cs
@@ -7,6 +7,7 @@ namespace MyToolsYourToolsBackend.Application.Services
 {
     public interface IGroupService
     {
+        bool checkIfNameIsUnique(GroupForCreationDto group);
         IEnumerable<GroupDto> GetUserGroups(Guid userId);
         IEnumerable<GroupDto> GetAllGroups();
         GroupDto AddGroup(GroupForCreationDto offer);

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/IGroupService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/IGroupService.cs
@@ -7,9 +7,9 @@ namespace MyToolsYourToolsBackend.Application.Services
 {
     public interface IGroupService
     {
-        bool checkIfNameIsUnique(GroupForCreationDto group);
+        bool checkIfNameAlreadyExists(GroupForCreationDto group);
         IEnumerable<GroupDto> GetUserGroups(Guid userId);
         IEnumerable<GroupDto> GetAllGroups();
-        GroupDto AddGroup(GroupForCreationDto offer);
+        GroupDto AddGroup(GroupForCreationDto group);
     }
 }

--- a/MyToolsYourToolsClient/package-lock.json
+++ b/MyToolsYourToolsClient/package-lock.json
@@ -136,8 +136,8 @@
           "integrity": "sha512-9BZwxR85dNsjWz3blyxdOhTgtnQvv3OEs5xofI0wPYTwu5kaWxS08UuD1oI7WLBLpRO+ylf0ofnXLXWmGb2WMw==",
           "dev": true,
           "requires": {
-            "source-list-map": "^2.0.0",
-            "source-map": "~0.6.1"
+            "source-list-map": "2.0.1",
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -481,6 +481,14 @@
         "tslib": "1.9.3"
       }
     },
+    "@ng-bootstrap/ng-bootstrap": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@ng-bootstrap/ng-bootstrap/-/ng-bootstrap-4.0.2.tgz",
+      "integrity": "sha512-SBsN8ORvj/WXpZGSyR2+CRkg6GCtax5+fsLKt9ImHKUVWwePVqRxiGlnxXqwNPHQ46vOdd7nDN9cwE7dfbGaAQ==",
+      "requires": {
+        "tslib": "1.9.3"
+      }
+    },
     "@ngtools/webpack": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-7.2.1.tgz",
@@ -519,8 +527,8 @@
           "integrity": "sha512-9BZwxR85dNsjWz3blyxdOhTgtnQvv3OEs5xofI0wPYTwu5kaWxS08UuD1oI7WLBLpRO+ylf0ofnXLXWmGb2WMw==",
           "dev": true,
           "requires": {
-            "source-list-map": "^2.0.0",
-            "source-map": "~0.6.1"
+            "source-list-map": "2.0.1",
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -2405,19 +2413,19 @@
           "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
           "dev": true,
           "requires": {
-            "bluebird": "^3.5.1",
-            "chownr": "^1.0.1",
-            "glob": "^7.1.2",
-            "graceful-fs": "^4.1.11",
-            "lru-cache": "^4.1.1",
-            "mississippi": "^2.0.0",
-            "mkdirp": "^0.5.1",
-            "move-concurrently": "^1.0.1",
-            "promise-inflight": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "ssri": "^5.2.4",
-            "unique-filename": "^1.1.0",
-            "y18n": "^4.0.0"
+            "bluebird": "3.5.3",
+            "chownr": "1.1.1",
+            "glob": "7.1.3",
+            "graceful-fs": "4.1.15",
+            "lru-cache": "4.1.5",
+            "mississippi": "2.0.0",
+            "mkdirp": "0.5.1",
+            "move-concurrently": "1.0.1",
+            "promise-inflight": "1.0.1",
+            "rimraf": "2.6.2",
+            "ssri": "5.3.0",
+            "unique-filename": "1.1.1",
+            "y18n": "4.0.0"
           }
         },
         "mississippi": {
@@ -2426,16 +2434,16 @@
           "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
           "dev": true,
           "requires": {
-            "concat-stream": "^1.5.0",
-            "duplexify": "^3.4.2",
-            "end-of-stream": "^1.1.0",
-            "flush-write-stream": "^1.0.0",
-            "from2": "^2.1.0",
-            "parallel-transform": "^1.1.0",
-            "pump": "^2.0.1",
-            "pumpify": "^1.3.3",
-            "stream-each": "^1.1.0",
-            "through2": "^2.0.0"
+            "concat-stream": "1.6.2",
+            "duplexify": "3.6.1",
+            "end-of-stream": "1.4.1",
+            "flush-write-stream": "1.0.3",
+            "from2": "2.3.0",
+            "parallel-transform": "1.1.0",
+            "pump": "2.0.1",
+            "pumpify": "1.5.1",
+            "stream-each": "1.2.3",
+            "through2": "2.0.5"
           }
         },
         "pump": {
@@ -2444,8 +2452,8 @@
           "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "ssri": {
@@ -2454,7 +2462,7 @@
           "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.1"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -2921,7 +2929,7 @@
           "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
           "dev": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           }
         },
         "pify": {
@@ -3888,21 +3896,19 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "delegates": "1.0.0",
+            "readable-stream": "2.3.6"
           }
         },
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -3917,20 +3923,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3971,7 +3974,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "fs.realpath": {
@@ -3986,14 +3989,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aproba": "^1.0.3",
-            "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
-            "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
+            "aproba": "1.2.0",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
           }
         },
         "glob": {
@@ -4002,12 +4005,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "has-unicode": {
@@ -4022,7 +4025,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "ignore-walk": {
@@ -4031,7 +4034,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "inflight": {
@@ -4040,15 +4043,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4060,9 +4062,8 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "isarray": {
@@ -4075,7 +4076,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
@@ -4083,17 +4083,15 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "minizlib": {
@@ -4102,14 +4100,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.2.1"
+            "minipass": "2.2.4"
           }
         },
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4126,9 +4123,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "debug": "^2.1.2",
-            "iconv-lite": "^0.4.4",
-            "sax": "^1.2.4"
+            "debug": "2.6.9",
+            "iconv-lite": "0.4.21",
+            "sax": "1.2.4"
           }
         },
         "node-pre-gyp": {
@@ -4137,16 +4134,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "detect-libc": "^1.0.2",
-            "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
-            "nopt": "^4.0.1",
-            "npm-packlist": "^1.1.6",
-            "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
-            "rimraf": "^2.6.1",
-            "semver": "^5.3.0",
-            "tar": "^4"
+            "detect-libc": "1.0.3",
+            "mkdirp": "0.5.1",
+            "needle": "2.2.0",
+            "nopt": "4.0.1",
+            "npm-packlist": "1.1.10",
+            "npmlog": "4.1.2",
+            "rc": "1.2.7",
+            "rimraf": "2.6.2",
+            "semver": "5.5.0",
+            "tar": "4.4.1"
           }
         },
         "nopt": {
@@ -4155,8 +4152,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "abbrev": "1",
-            "osenv": "^0.1.4"
+            "abbrev": "1.1.1",
+            "osenv": "0.1.5"
           }
         },
         "npm-bundled": {
@@ -4171,8 +4168,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ignore-walk": "^3.0.1",
-            "npm-bundled": "^1.0.1"
+            "ignore-walk": "3.0.1",
+            "npm-bundled": "1.0.3"
           }
         },
         "npmlog": {
@@ -4181,17 +4178,16 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
           }
         },
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4203,9 +4199,8 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "os-homedir": {
@@ -4226,8 +4221,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.0"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "path-is-absolute": {
@@ -4248,10 +4243,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
-            "ini": "~1.3.0",
-            "minimist": "^1.2.0",
-            "strip-json-comments": "~2.0.1"
+            "deep-extend": "0.5.1",
+            "ini": "1.3.5",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
           },
           "dependencies": {
             "minimist": {
@@ -4268,13 +4263,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.0",
+            "safe-buffer": "5.1.1",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "rimraf": {
@@ -4283,7 +4278,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-buffer": {
@@ -4325,11 +4320,10 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string_decoder": {
@@ -4338,7 +4332,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.1"
           }
         },
         "strip-ansi": {
@@ -4346,7 +4340,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-json-comments": {
@@ -4361,13 +4355,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
-            "yallist": "^3.0.2"
+            "chownr": "1.0.1",
+            "fs-minipass": "1.2.5",
+            "minipass": "2.2.4",
+            "minizlib": "1.1.0",
+            "mkdirp": "0.5.1",
+            "safe-buffer": "5.1.1",
+            "yallist": "3.0.2"
           }
         },
         "util-deprecate": {
@@ -4382,7 +4376,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "1.0.2"
           }
         },
         "wrappy": {
@@ -6075,9 +6069,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.7",
+            "mime-types": "2.1.21"
           }
         },
         "har-schema": {
@@ -6094,8 +6088,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "^6.5.5",
-            "har-schema": "^2.0.0"
+            "ajv": "6.6.2",
+            "har-schema": "2.0.0"
           }
         },
         "http-signature": {
@@ -6105,9 +6099,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.15.2"
           }
         },
         "oauth-sign": {
@@ -6145,26 +6139,26 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.8.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.7",
+            "extend": "3.0.2",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.3",
+            "har-validator": "5.1.3",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.21",
+            "oauth-sign": "0.9.0",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.2",
+            "tough-cookie": "2.4.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
           }
         },
         "source-map": {
@@ -6181,8 +6175,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
+            "psl": "1.1.31",
+            "punycode": "1.4.1"
           }
         }
       }
@@ -6339,7 +6333,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "ms": {
@@ -8175,11 +8169,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "del": {
@@ -8188,13 +8182,13 @@
           "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
           "dev": true,
           "requires": {
-            "globby": "^5.0.0",
-            "is-path-cwd": "^1.0.0",
-            "is-path-in-cwd": "^1.0.0",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "rimraf": "^2.2.8"
+            "globby": "5.0.0",
+            "is-path-cwd": "1.0.0",
+            "is-path-in-cwd": "1.0.1",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "rimraf": "2.6.2"
           }
         },
         "form-data": {
@@ -8203,9 +8197,9 @@
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.7",
+            "mime-types": "2.1.21"
           }
         },
         "globby": {
@@ -8214,12 +8208,12 @@
           "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
           "dev": true,
           "requires": {
-            "array-union": "^1.0.1",
-            "arrify": "^1.0.0",
-            "glob": "^7.0.3",
-            "object-assign": "^4.0.1",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.3",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "har-schema": {
@@ -8234,8 +8228,8 @@
           "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
           "dev": true,
           "requires": {
-            "ajv": "^6.5.5",
-            "har-schema": "^2.0.0"
+            "ajv": "6.6.2",
+            "har-schema": "2.0.0"
           }
         },
         "http-signature": {
@@ -8244,9 +8238,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.15.2"
           }
         },
         "minimist": {
@@ -8285,26 +8279,26 @@
           "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.0",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.4.3",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.8.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.7",
+            "extend": "3.0.2",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.3",
+            "har-validator": "5.1.3",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.21",
+            "oauth-sign": "0.9.0",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.1.2",
+            "tough-cookie": "2.4.3",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.3.2"
           }
         },
         "source-map-support": {
@@ -8328,8 +8322,8 @@
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "dev": true,
           "requires": {
-            "psl": "^1.1.24",
-            "punycode": "^1.4.1"
+            "psl": "1.1.31",
+            "punycode": "1.4.1"
           }
         },
         "webdriver-manager": {
@@ -9393,7 +9387,7 @@
           "integrity": "sha1-ckGdSovn1s51FI/YsyTlk6cRwu0=",
           "dev": true,
           "requires": {
-            "os-tmpdir": "~1.0.1"
+            "os-tmpdir": "1.0.2"
           }
         }
       }
@@ -11404,9 +11398,9 @@
           "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
           "dev": true,
           "requires": {
-            "string-width": "^2.1.1",
-            "strip-ansi": "^4.0.0",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "wrap-ansi": "2.1.0"
           },
           "dependencies": {
             "strip-ansi": {
@@ -11415,7 +11409,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -11426,11 +11420,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "nice-try": "1.0.5",
+            "path-key": "2.0.1",
+            "semver": "5.6.0",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "debug": {
@@ -11439,7 +11433,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "decamelize": {
@@ -11472,7 +11466,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "invert-kv": {
@@ -11487,7 +11481,7 @@
           "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
           "dev": true,
           "requires": {
-            "invert-kv": "^2.0.0"
+            "invert-kv": "2.0.0"
           }
         },
         "locate-path": {
@@ -11496,8 +11490,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "mem": {
@@ -11506,9 +11500,9 @@
           "integrity": "sha512-WQxG/5xYc3tMbYLXoXPm81ET2WDULiU5FxbuIoNbJqLOOI8zehXFdZuiUEgfdrU2mVB1pxBZUGlYORSrpuJreA==",
           "dev": true,
           "requires": {
-            "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^1.0.0",
-            "p-is-promise": "^1.1.0"
+            "map-age-cleaner": "0.1.3",
+            "mimic-fn": "1.2.0",
+            "p-is-promise": "1.1.0"
           }
         },
         "ms": {
@@ -11543,7 +11537,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.1.0"
           }
         },
         "p-try": {
@@ -11564,18 +11558,18 @@
           "integrity": "sha512-e7SkEx6N6SIZ5c5H22RTZae61qtn3PYUE8JYbBFlK9sYmh3DMQ6E5ygtaG/2BW0JZi4WGgTR2IV5ChqlqrDGVQ==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^2.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^10.1.0"
+            "cliui": "4.1.0",
+            "decamelize": "2.0.0",
+            "find-up": "3.0.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "3.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "4.0.0",
+            "yargs-parser": "10.1.0"
           }
         },
         "yargs-parser": {
@@ -11584,7 +11578,7 @@
           "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           }
         }
       }

--- a/MyToolsYourToolsClient/package.json
+++ b/MyToolsYourToolsClient/package.json
@@ -21,6 +21,7 @@
     "@angular/platform-browser": "7.1.3",
     "@angular/platform-browser-dynamic": "7.1.3",
     "@angular/router": "7.1.3",
+    "@ng-bootstrap/ng-bootstrap": "^4.0.2",
     "bootstrap": "^4.1.3",
     "core-js": "^2.4.1",
     "hoek": "^6.1.2",

--- a/MyToolsYourToolsClient/src/app/admin-panel/create-group/create-group.component.ts
+++ b/MyToolsYourToolsClient/src/app/admin-panel/create-group/create-group.component.ts
@@ -31,7 +31,6 @@ export class CreateGroupComponent implements OnInit {
         this.createdGroup.emit(result);
       },
       error => {
-        console.log(error);
         this.alertService.error(error.error);
         this.createdGroup.emit(null);
       }

--- a/MyToolsYourToolsClient/src/app/admin-panel/create-group/create-group.component.ts
+++ b/MyToolsYourToolsClient/src/app/admin-panel/create-group/create-group.component.ts
@@ -31,7 +31,8 @@ export class CreateGroupComponent implements OnInit {
         this.createdGroup.emit(result);
       },
       error => {
-        this.alertService.error('Nie udało utworzyć się grupy.');
+        console.log(error);
+        this.alertService.error(error.error);
         this.createdGroup.emit(null);
       }
     );

--- a/MyToolsYourToolsClient/src/app/admin-panel/create-group/create-group.component.ts
+++ b/MyToolsYourToolsClient/src/app/admin-panel/create-group/create-group.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, Output, EventEmitter } from '@angular/core';
 import { GroupService } from '../../services/group.service';
+import { AlertService } from '../../services/alert.service';
 import { Group } from '../../models/Group';
 
 declare var $: any;
@@ -16,19 +17,21 @@ export class CreateGroupComponent implements OnInit {
 
   group: Group = {id: '', name: ''};
 
-  constructor(private groupService: GroupService) { }
+  constructor(
+    private groupService: GroupService,
+    private alertService: AlertService) { }
 
   ngOnInit() {}
 
   addGroup() {
     this.groupService.addGroup(this.group).subscribe(
       result => {
-        console.log('Dodano grupe');
+        this.alertService.success('Grupa utworzona pomyślnie.');
         $('#createGroupModal').modal('hide');
         this.createdGroup.emit(result);
       },
       error => {
-        console.log(error);
+        this.alertService.error('Nie udało utworzyć się grupy.');
         this.createdGroup.emit(null);
       }
     );

--- a/MyToolsYourToolsClient/src/app/alert/alert.component.css
+++ b/MyToolsYourToolsClient/src/app/alert/alert.component.css
@@ -1,0 +1,13 @@
+.alert-wrapper {
+  position: fixed;
+  top: 30px;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
+  width: 50%;
+  min-width: 300px;
+  max-width: 600px;
+  z-index: 2000;
+  display: inline-block;
+  text-align: center;
+}

--- a/MyToolsYourToolsClient/src/app/alert/alert.component.html
+++ b/MyToolsYourToolsClient/src/app/alert/alert.component.html
@@ -1,0 +1,3 @@
+<div class="alert-wrapper">
+  <ngb-alert *ngIf="alert" [type]="alert.type" (close)="alert = null">{{ alert.message }}</ngb-alert>
+</div>

--- a/MyToolsYourToolsClient/src/app/alert/alert.component.spec.ts
+++ b/MyToolsYourToolsClient/src/app/alert/alert.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AlertComponent } from './alert.component';
+
+describe('AlertComponent', () => {
+  let component: AlertComponent;
+  let fixture: ComponentFixture<AlertComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AlertComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AlertComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/MyToolsYourToolsClient/src/app/alert/alert.component.ts
+++ b/MyToolsYourToolsClient/src/app/alert/alert.component.ts
@@ -1,0 +1,24 @@
+import { Component, OnInit } from '@angular/core';
+import { debounce } from 'rxjs/operators';
+import { AlertService } from '../services/alert.service';
+import { Alert } from '../models/Alert';
+import { timer } from 'rxjs';
+
+@Component({
+  selector: 'app-alert',
+  templateUrl: './alert.component.html',
+  styleUrls: ['./alert.component.css']
+})
+export class AlertComponent implements OnInit {
+
+  alert: Alert;
+
+  constructor(private alertService: AlertService) { }
+
+  ngOnInit() {
+    this.alertService.getAlertSubject().subscribe(alert => this.alert = alert);
+    this.alertService.getAlertSubject().pipe(
+      debounce(() => timer(this.alert.displayTime))
+    ).subscribe(() => this.alert = null);
+  }
+}

--- a/MyToolsYourToolsClient/src/app/app.component.html
+++ b/MyToolsYourToolsClient/src/app/app.component.html
@@ -1,3 +1,4 @@
 <!--The content below is only a placeholder and can be replaced.-->
 <app-navbar></app-navbar>
+<app-alert></app-alert>
 <router-outlet></router-outlet>

--- a/MyToolsYourToolsClient/src/app/app.module.ts
+++ b/MyToolsYourToolsClient/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { HttpClientModule } from '@angular/common/http';
+import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { NgbAlertModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { AppComponent } from './app.component';
@@ -30,6 +30,7 @@ import { ReactiveFormsModule } from '@angular/forms';
 import { LoginComponent } from './login/login.component';
 import { CreateGroupComponent } from './admin-panel/create-group/create-group.component';
 import { AlertComponent } from './alert/alert.component';
+import { ErrorInterceptor } from './interceptors/error.interceptor';
 
 
 
@@ -63,7 +64,8 @@ import { AlertComponent } from './alert/alert.component';
     HttpClientModule,
     NgbAlertModule
   ],
-  providers: [OfferService, UserService, GroupService, RentService, NotificationService],
+  providers: [OfferService, UserService, GroupService, RentService, NotificationService,
+    { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true }],
   bootstrap: [AppComponent]
 })
 export class AppModule { }

--- a/MyToolsYourToolsClient/src/app/app.module.ts
+++ b/MyToolsYourToolsClient/src/app/app.module.ts
@@ -2,6 +2,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
+import { NgbAlertModule } from '@ng-bootstrap/ng-bootstrap';
 
 import { AppComponent } from './app.component';
 import { NavbarComponent } from './navbar/navbar.component';
@@ -28,6 +29,7 @@ import { GroupsComponent } from './admin-panel/groups/groups.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { LoginComponent } from './login/login.component';
 import { CreateGroupComponent } from './admin-panel/create-group/create-group.component';
+import { AlertComponent } from './alert/alert.component';
 
 
 
@@ -50,14 +52,16 @@ import { CreateGroupComponent } from './admin-panel/create-group/create-group.co
     OfferViewComponent,
     OfferCreatorComponent,
     LoginComponent,
-    CreateGroupComponent
+    CreateGroupComponent,
+    AlertComponent
   ],
   imports: [
     BrowserModule,
     AppRoutingModule,
     FormsModule,
     ReactiveFormsModule,
-    HttpClientModule
+    HttpClientModule,
+    NgbAlertModule
   ],
   providers: [OfferService, UserService, GroupService, RentService, NotificationService],
   bootstrap: [AppComponent]

--- a/MyToolsYourToolsClient/src/app/interceptors/error.interceptor.ts
+++ b/MyToolsYourToolsClient/src/app/interceptors/error.interceptor.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@angular/core';
+import { HttpRequest, HttpHandler, HttpEvent, HttpInterceptor } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+import { UserService } from '../services/user.service';
+
+@Injectable()
+export class ErrorInterceptor implements HttpInterceptor {
+    constructor(private userService: UserService) {}
+
+    intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+      return next.handle(request).pipe(
+        catchError(err => {
+          if (err.status === 400) { // when Bad Request
+            if (typeof err.error !== 'string') { // when error message is not string
+              const errorDetails = Object.values(err.error);
+              let errorMessage = '';
+              errorDetails.forEach(eD => errorMessage += eD + ' ');
+              err.error = errorMessage; // stringify all error messages
+            }
+          }
+          return throwError(err); // rethrow error
+        }
+      ));
+    }
+}

--- a/MyToolsYourToolsClient/src/app/models/Alert.ts
+++ b/MyToolsYourToolsClient/src/app/models/Alert.ts
@@ -1,0 +1,21 @@
+export class Alert {
+  type: string;
+  message: string;
+  displayTime: number;
+
+  constructor(message, type?) {
+    this.message = message;
+    this.type = type || 'info';
+    switch (this.type) {
+      case 'success':
+        this.displayTime = 2300;
+        break;
+      case 'danger':
+        this.displayTime = 60000;
+        break;
+      default:
+        this.displayTime = 10000;
+        break;
+    }
+  }
+}

--- a/MyToolsYourToolsClient/src/app/services/alert.service.spec.ts
+++ b/MyToolsYourToolsClient/src/app/services/alert.service.spec.ts
@@ -1,0 +1,12 @@
+import { TestBed } from '@angular/core/testing';
+
+import { AlertService } from './alert.service';
+
+describe('AlertService', () => {
+  beforeEach(() => TestBed.configureTestingModule({}));
+
+  it('should be created', () => {
+    const service: AlertService = TestBed.get(AlertService);
+    expect(service).toBeTruthy();
+  });
+});

--- a/MyToolsYourToolsClient/src/app/services/alert.service.ts
+++ b/MyToolsYourToolsClient/src/app/services/alert.service.ts
@@ -1,0 +1,43 @@
+
+import { Injectable } from '@angular/core';
+import { Alert } from '../models/Alert';
+import { Subject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AlertService {
+
+  private alertSubject = new Subject<Alert>();
+
+  constructor() { }
+
+  public showAlert (message, type) {
+    const alert = new Alert(message, type);
+    this.alertSubject.next(alert);
+  }
+
+  public error (message) {
+    const alert = new Alert(message, 'danger');
+    this.alertSubject.next(alert);
+  }
+
+  public success (message) {
+    const alert = new Alert(message, 'success');
+    this.alertSubject.next(alert);
+  }
+
+  public info (message) {
+    const alert = new Alert(message, 'info');
+    this.alertSubject.next(alert);
+  }
+
+  public warining (message) {
+    const alert = new Alert(message, 'warning');
+    this.alertSubject.next(alert);
+  }
+
+  public getAlertSubject(): Subject<Alert> {
+    return this.alertSubject;
+  }
+}


### PR DESCRIPTION
Dodałem globalne alerty na froncie. Do przetestowania w panelu admina -> Utwórz nową grupę.
Opisze jak ich używać:
Możemy ich używać w dowolnym komponencie, tylko do konstruktora musimy wstrzyknąć AlertService:

constructor(private alertService: AlertService, ...) { }

Przykład użycia przy tworzeniu nowej grupy:

addGroup() {
    this.groupService.addGroup(this.group).subscribe(
      result => {
        this.alertService.success('Grupa utworzona pomyślnie.');
        $('#createGroupModal').modal('hide');
        this.createdGroup.emit(result);
      },
      error => {
        console.log(error);
        this.alertService.error(error.error);
        this.createdGroup.emit(null);
      }
    );
  }

Używamy SUBSCRIBE na metodzie dowolnego serwisu jakiego potrzebujemy i w nim podajemy dwa argumenty (nazwy mogą być dowolne tylko kolejność jest ważna), ja używam result i error. "Scieżka" result wykonuje się jak zwracane jest przez HTTP kod powodzenia np. OK wtedy używam serwisu do wyświetlenia alertu sukcesu (reszta nie ważna). W obiekcie result jest to co zwraca mi odpowiednia metoda kontrolera z backendu. W moim przypadku:

[HttpPost("groups")]
        public IActionResult AddGroup([FromBody]GroupForCreationDto groupFromBody)
        {
            if (_groupService.checkIfNameIsUnique(groupFromBody))
            {
                return BadRequest("Grupa o podanej nazwie już istnieje. Podaj inną nazwę.");
            }

            var groupToReturn = _groupService.AddGroup(groupFromBody);
            return Created(nameof(GetGroups), groupToReturn);
        }

Metoda kontrolera zwraca nowo utworzoną grupę zaszytą w odpowiedzi serwera o statusie CREATED.
Metoda serwisu groupService.AddGroup(...) zwraca mi DTO grupy, która na foncie jest parsowana do JSONa:
     GroupDto AddGroup(GroupForCreationDto group);

"Scieżka" error się wykonuje gdy HTTP zwróci kod niepowodzenia np. BAD_REQUEST, wtedy alertServicem wyświetlam error z komunikatem zwracanym z backendu, który zaszyty jest w polu error obiektu error (sorry za nazewnictwo ale tak się to stosuje).

Dodałem jeszcze ERROR.INTERCEPTORa - w skrócie działa to jak taki job, który sprawdza każdy HttpResponse wysyłany z backendu przed przesłaniem go do serwisu. W nim parsuje odpowiedzi o kodzie 400 - BAD_REQUEST tak, żeby zawsze w polu error.error znajdował się pojedynczy string ze zwracaną odpowiedzią z backendu. Czasami może być ona wysyłana jako JSON, np gdy jest zwracanych kilka błędów na raz, w moim przykładzie to jest niemożliwe, ale jak będą bardziej rozbudowane formularze to może się coś takiego stać)

Na backendzie dodałem wcześniej wspomniane wysyłanie errorów, gdy nie można dodać nowej grupy. Unikalność nazwy jest sprawdzana przez nową metodę serwisu checkIfNameAlreadyExists(...) i jeśli tak to z palca wysyłamy Bad_Request (jak w powyższej metodzie kontrolera)
Sprawdzanie czy nazwa nowej grupy nie jest nullem lub empty jest z poziomu GroupForCreationDto, przez użycie odpowiedniej anotacji:
        [Required(AllowEmptyStrings = false, ErrorMessage = "Podaj nazwę grupy.")]
        public string Name { get; set; }

Do użycia alertów na froncie musiałem zainstalować nową paczkę npm'em, jeśli wam nie zadziała z automatu musicie zrobić:
         npm install --save @ng-bootstrap/ng-bootstrap

