### PR TITLE
B+f rents

### DIFF
--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/NotificationsController.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/NotificationsController.cs
@@ -74,7 +74,7 @@ namespace MyToolsYourToolsBackend.API.Controllers
            else return NotFound();
         }
 
-        [HttpGet("{userId}/{offerId}/checkIfCanSend")]
+        [HttpGet("{userId}/{offerId}/check-if-can-send-rent-request")]
         public IActionResult UserCanSendRentRequest(Guid userId, Guid offerId)
         {
             if(!_userService.CheckIfUserExists(userId)

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/NotificationsController.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/NotificationsController.cs
@@ -20,12 +20,14 @@ namespace MyToolsYourToolsBackend.API.Controllers
         private INotificationService _notificationService;
         private IUserService _userService;
         private IOfferService _offerService;
+        private IRentService _rentService;
 
-        public NotificationsController(INotificationService notificationService, IUserService userService, IOfferService offerService)
+        public NotificationsController(INotificationService notificationService, IUserService userService, IOfferService offerService, IRentService rentService)
         {
             _notificationService = notificationService;
             _userService = userService;
             _offerService = offerService;
+            _rentService = rentService;
         }
        
 
@@ -52,6 +54,8 @@ namespace MyToolsYourToolsBackend.API.Controllers
 
             if(notificationFromBody.Type == NotificationType.RentRequest)
             {
+                var pointsRentCost = 100;
+
                 if (!_offerService.CheckIfOfferIsActive(notificationFromBody.OfferId))
                 {
                     return BadRequest("Oferta nieaktywna.");
@@ -60,6 +64,10 @@ namespace MyToolsYourToolsBackend.API.Controllers
                     notificationFromBody.TargetUserId, notificationFromBody.OfferId))
                 {
                     return BadRequest("Proœba o wypo¿yczenie dla tej oferty ju¿ zosta³a przes³ana.");
+                }
+                else if (!_rentService.CheckIfUserHasEnoughPoints(notificationFromBody.TargetUserId, pointsRentCost))
+                {
+                    return BadRequest("Niewystarczaj¹ca iloœæ punktów na zrealizowanie wypo¿yczenia.");
                 }
             }
             

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/NotificationsController.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/NotificationsController.cs
@@ -78,8 +78,15 @@ namespace MyToolsYourToolsBackend.API.Controllers
 
         [HttpDelete("{id}")]
         public IActionResult DeleteNotification(Guid id){
-           if( _notificationService.DeleteNotification(id)) return Ok();
-           else return NotFound();
+
+            if (_notificationService.DeleteNotification(id))
+            {
+                return Ok();
+            }
+            else
+            {
+                return NotFound();
+            }
         }
 
         [HttpGet("{userId}/{offerId}/check-if-can-send-rent-request")]

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/RentController.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/RentController.cs
@@ -59,9 +59,7 @@ namespace MyToolsYourToolsBackend.API.Controllers
                 return NotFound();
             }
 
-            _rentService.DeleteRent(offerId);
-
-            return NoContent();
+            return Ok(_rentService.DeleteRent(offerId));
         }
     }
 }

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/RentController.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/RentController.cs
@@ -38,16 +38,6 @@ namespace MyToolsYourToolsBackend.API.Controllers
 
             int pointsRentCost = 100;
 
-            if(!_rentService.CheckIfUserHasEnoughPoints(rentFromBody.BorrowerId, pointsRentCost))
-            {
-                return BadRequest("Niewystarczająca ilość punktów na zrealizowanie wypożyczenia.");
-            }
-
-            if (!_offerService.CheckIfOfferIsActive(rentFromBody.OfferId))
-            {
-                return BadRequest("Oferta nieaktywna.");
-            }
-
             _rentService.AddRent(rentFromBody, pointsRentCost);
 
             return NoContent();

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/RentController.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Controllers/RentController.cs
@@ -28,7 +28,7 @@ namespace MyToolsYourToolsBackend.API.Controllers
         }
 
         [HttpPost("rents")]
-        public IActionResult AddRent([FromBody]RentForCreationDto rentFromBody)
+        public IActionResult AddRent([FromBody]RentDto rentFromBody)
         {
             if (!_userService.CheckIfUserExists(rentFromBody.BorrowerId)
                 || !_offerService.CheckIfOfferExists(rentFromBody.OfferId))
@@ -53,9 +53,7 @@ namespace MyToolsYourToolsBackend.API.Controllers
 
             int pointsReturnReward = 100;
 
-            _rentService.DeleteRent(offerId, pointsReturnReward);
-
-            return NoContent();
+            return Ok(_rentService.DeleteRent(offerId, pointsReturnReward));
         }
     }
 }

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Infrastructure/AutoMapperConfiguration.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.API/Infrastructure/AutoMapperConfiguration.cs
@@ -34,8 +34,9 @@ namespace MyToolsYourToolsBackend.API.Infrastructure
                 .ForMember(dest=>dest.OfferName,
                 opt=>opt.MapFrom(src=>src.Offer.Tool));
               
-                cfg.CreateMap<RentForCreationDto, Rent>();
-   
+                cfg.CreateMap<RentDto, Rent>();
+                cfg.CreateMap<Rent, RentDto>();
+
                 cfg.CreateMap<OpinionForCreationDto, Opinion>();
                 cfg.CreateMap<Opinion, OpinionDto>();
 

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Dtos/RentDto.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Dtos/RentDto.cs
@@ -5,7 +5,7 @@ using System.Text;
 
 namespace MyToolsYourToolsBackend.Application.Dtos
 {
-    public class RentForCreationDto
+    public class RentDto
     {
         public Guid OfferId { get; set; }
         public Guid BorrowerId { get; set; }

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/INotificationService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/INotificationService.cs
@@ -12,7 +12,6 @@ namespace MyToolsYourToolsBackend.Application.Services
         IEnumerable<NotificationDto> GetNotificationsForUser(Guid userId);
         NotificationDto AddNotification(NotificationForCreationDto notification);
         bool DeleteNotification(Guid notificationId);
-        NotificationDto SendNotificationFromServer(Guid toUserId, Guid fromUserId, Guid offerId, NotificationType type);
         bool CheckIfUserAlreadySendRentRequest(Guid userId, Guid offerId);
     }
 }

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/IRentService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/IRentService.cs
@@ -9,7 +9,7 @@ namespace MyToolsYourToolsBackend.Application.Services
     public interface IRentService
     {
         bool CheckIfUserHasEnoughPoints(Guid userId, int sumToSubtract);
-        Rent AddRent(RentForCreationDto rent, int pointsCost);
-        void DeleteRent(Guid offerId, int pointsReward);
+        Rent AddRent(RentDto rent, int pointsCost);
+        RentDto DeleteRent(Guid offerId, int pointsReward);
     }
 }

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/NotificationService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/NotificationService.cs
@@ -14,10 +14,12 @@ namespace MyToolsYourToolsBackend.Application.Services
     public class NotificationService : INotificationService
     {
         private AppDbContext _dbContext;
+        private IPointsService _pointsService;
 
-        public NotificationService(AppDbContext dbContext)
+        public NotificationService(AppDbContext dbContext, IPointsService pointsService)
         {
             _dbContext = dbContext;
+            _pointsService = pointsService;
         }
 
         public bool userHasNotifications(Guid userId)

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/NotificationService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/NotificationService.cs
@@ -82,20 +82,6 @@ namespace MyToolsYourToolsBackend.Application.Services
             }
         }
 
-        public NotificationDto SendNotificationFromServer(Guid toUserId, Guid fromUserId, Guid offerId, NotificationType type)
-        {
-            var notificationToSend = new NotificationForCreationDto()
-            {
-                OwnerId = toUserId,
-                TargetUserId = fromUserId,
-                OfferId = offerId,
-                Type = type
-            };
-
-            return AddNotification(notificationToSend);
-
-        }
-
         public bool CheckIfUserAlreadySendRentRequest(Guid userId, Guid offerId)
         {
             return _dbContext.Notifications.Any(n => n.TargetUserId == userId

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/NotificationService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/NotificationService.cs
@@ -14,10 +14,12 @@ namespace MyToolsYourToolsBackend.Application.Services
     public class NotificationService : INotificationService
     {
         private AppDbContext _dbContext;
+        private IRentService _rentService;
 
-        public NotificationService(AppDbContext dbContext)
+        public NotificationService(AppDbContext dbContext, IRentService rentService)
         {
             _dbContext = dbContext;
+            _rentService = rentService;
         }
 
         public bool userHasNotifications(Guid userId)
@@ -37,7 +39,16 @@ namespace MyToolsYourToolsBackend.Application.Services
         {
             var newNotification = Mapper.Map<Notification>(notification);
             _dbContext.Notifications.Add(newNotification);
-            if(_dbContext.SaveChanges() == 0)
+
+            // get deposit if rent request
+            if (newNotification.Type == NotificationType.RentRequest)
+            {
+                var pointsRentCost = 100;
+                var borrower = _dbContext.Users.FirstOrDefault(u => u.Id == notification.TargetUserId);
+                borrower.Points -= pointsRentCost;
+            }
+
+            if (_dbContext.SaveChanges() == 0)
             {
                 throw new Exception("Could not add notification");
             }
@@ -47,21 +58,31 @@ namespace MyToolsYourToolsBackend.Application.Services
         }
 
         public bool DeleteNotification(Guid notificationId)
-        {
-            
+        {  
             var notificationToDelete = _dbContext.Notifications.FirstOrDefault(n => n.Id==notificationId);
-            if(notificationToDelete!=null)
+            if (notificationToDelete != null)
             {
-            _dbContext.Notifications.Remove(notificationToDelete);
-            
-            if(_dbContext.SaveChanges() == 0)
+                _dbContext.Notifications.Remove(notificationToDelete);
+
+                // return deposit if rent request
+                if (notificationToDelete.Type == NotificationType.RentRequest)
+                {
+                    var pointsRentCost = 100;
+                    var borrower = _dbContext.Users.FirstOrDefault(u =>
+                                                u.Id == notificationToDelete.TargetUserId);
+                    borrower.Points += pointsRentCost;
+                }
+
+                if (_dbContext.SaveChanges() == 0)
+                {
+                    throw new Exception("Could not delete");
+                }
+                return true;
+            }
+            else
             {
-                throw new Exception("Could not delete");
-               
+                return false;
             }
-            return true;
-            }
-            else return false;
         }
 
         public NotificationDto SendNotificationFromServer(Guid toUserId, Guid fromUserId, Guid offerId, NotificationType type)

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/NotificationService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/NotificationService.cs
@@ -14,12 +14,10 @@ namespace MyToolsYourToolsBackend.Application.Services
     public class NotificationService : INotificationService
     {
         private AppDbContext _dbContext;
-        private IRentService _rentService;
 
-        public NotificationService(AppDbContext dbContext, IRentService rentService)
+        public NotificationService(AppDbContext dbContext)
         {
             _dbContext = dbContext;
-            _rentService = rentService;
         }
 
         public bool userHasNotifications(Guid userId)

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/RentService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/RentService.cs
@@ -41,27 +41,26 @@ namespace MyToolsYourToolsBackend.Application.Services
             offer.Status = OfferStatus.Rented;
 
             // delete all remaining rentRequests of this offer
-            var rentRequestsToRemove = _dbContext.Notifications
+            IList<Notification> rentRequestsToRemove = _dbContext.Notifications
                 .Where(n => n.OfferId == rent.OfferId
                         && n.Type == NotificationType.RentRequest
-                        && n.TargetUserId != borrower.Id);
-
-            foreach(var rentRequest in rentRequestsToRemove)
-            {
-                // need notificationService to return deposit
-                _notificationService.DeleteNotification(rentRequest.Id);
-            }
-            
-            
+                        && n.TargetUserId != borrower.Id).ToList<Notification>();
 
             _pointsService.ModifyPoints(rentingUser, new PointsModificationToolRentingStrategy());
-
             _pointsService.ModifyPoints(borrower, new PointsModificationToolBorrowingStrategy());
+
 
             if (_dbContext.SaveChanges() == 0)
             {
                 throw new Exception("Could not add rent");
-            }            
+            }
+
+            foreach (var rentRequest in rentRequestsToRemove)
+            {
+                // need notificationService to return deposit
+                _notificationService.DeleteNotification(rentRequest.Id);
+            }
+
             return rentToSave;
         }
 

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/RentService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/RentService.cs
@@ -26,7 +26,7 @@ namespace MyToolsYourToolsBackend.Application.Services
             return _dbContext.Users.FirstOrDefault(u => u.Id == userId).Points >= sumToSubstract;
         }
 
-        public Rent AddRent(RentForCreationDto rent, int pointsCost)
+        public Rent AddRent(RentDto rent, int pointsCost)
         {
             var rentToSave = Mapper.Map<Rent>(rent);
             var offer = _dbContext.Offers.FirstOrDefault(o => o.Id == rent.OfferId);
@@ -52,7 +52,7 @@ namespace MyToolsYourToolsBackend.Application.Services
 
         }
 
-        public void DeleteRent(Guid offerId, int pointsReward)
+        public RentDto DeleteRent(Guid offerId, int pointsReward)
         {
             var rentToDelete = _dbContext.Rents.FirstOrDefault(r => r.OfferId == offerId);
             var offer = _dbContext.Offers.FirstOrDefault(o => o.Id == offerId);
@@ -69,6 +69,8 @@ namespace MyToolsYourToolsBackend.Application.Services
 
             _notificationService.SendNotificationFromServer(borrower.Id,
                 offer.OwnerId, offerId, NotificationType.Opinion);
+
+            return Mapper.Map<RentDto>(rentToDelete);
 
         }
 

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/RentService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/RentService.cs
@@ -80,12 +80,8 @@ namespace MyToolsYourToolsBackend.Application.Services
             {
                 throw new Exception("Could not delete rent");
             }
-            
-            _notificationService.SendNotificationFromServer(borrower.Id,
-                offer.OwnerId, offerId, NotificationType.Opinion);
 
             return Mapper.Map<RentDto>(rentToDelete);
-
         }
     }
 }

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/RentService.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Services/RentService.cs
@@ -21,9 +21,9 @@ namespace MyToolsYourToolsBackend.Application.Services
             _notificationService = notificationService;
         }
 
-        public bool CheckIfUserHasEnoughPoints(Guid userId, int sumToSubstract)
+        public bool CheckIfUserHasEnoughPoints(Guid userId, int sumToSubtract)
         {
-            return _dbContext.Users.FirstOrDefault(u => u.Id == userId).Points >= sumToSubstract;
+            return _dbContext.Users.FirstOrDefault(u => u.Id == userId).Points >= sumToSubtract;
         }
 
         public Rent AddRent(RentDto rent, int pointsCost)
@@ -41,7 +41,12 @@ namespace MyToolsYourToolsBackend.Application.Services
                 .Where(n => n.OfferId == rent.OfferId
                         && n.Type == NotificationType.RentRequest
                         && n.TargetUserId != borrower.Id);
-            _dbContext.RemoveRange(rentRequestsToRemove);
+
+            foreach(var rentRequest in rentRequestsToRemove)
+            {
+                // need notificationService to return deposit
+                _notificationService.DeleteNotification(rentRequest.Id);
+            }
             
             if (_dbContext.SaveChanges() == 0)
             {

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Strategies/Points/PointsModificationGetDepositStrategy.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Strategies/Points/PointsModificationGetDepositStrategy.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MyToolsYourToolsBackend.Application.Strategies.Points
+{
+    public class PointsModificationGetDepositStrategy : IPointsModificationStrategy
+    {
+        public int Modify(int points)
+        {
+            return points -= 7;
+        }
+    }
+}

--- a/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Strategies/Points/PointsModificationReturnDepositStrategy.cs
+++ b/MyToolsYourToolsBackend/MyToolsYourToolsBackend.Application/Strategies/Points/PointsModificationReturnDepositStrategy.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace MyToolsYourToolsBackend.Application.Strategies.Points
+{
+    public class PointsModificationReturnDepositStrategy : IPointsModificationStrategy
+    {
+        public int Modify(int points)
+        {
+            return points += 7;
+        }
+    }
+}

--- a/MyToolsYourToolsClient/src/app/admin-panel/notifications/notifications.component.html
+++ b/MyToolsYourToolsClient/src/app/admin-panel/notifications/notifications.component.html
@@ -19,12 +19,12 @@
               </span>
             </div>
             <div clss="col-auto">
-              <button (click)="onRequestNotificationApproved(request.id)" class="btn btn-success btn-sm float-right" >
+              <button (click)="onRequestNotificationApproved(request)" class="btn btn-success btn-sm float-right" >
                 <i class="material-icons">done</i>
               </button>
             </div>
             <div clss="col-auto">
-              <button class="btn btn-danger btn-sm float-right" (click)="onRequestNotificationRejected(request.id)" >
+              <button class="btn btn-danger btn-sm float-right" (click)="onRequestNotificationRejected(request)" >
                 <i class="material-icons">clear</i>
               </button>
             </div>
@@ -47,9 +47,9 @@
               </form>
             </div>
             <div clss="col-auto">
-              <button  class="btn btn-success btn-sm float-right my-send-button" (click)="onOpinionSent(opinion.id)">Wyślij</button> 
+              <button  class="btn btn-success btn-sm float-right my-send-button" (click)="onOpinionSent(opinion.id)">Wyślij</button>
             </div>
-         
+
           </div>
         </div>
       </div>

--- a/MyToolsYourToolsClient/src/app/admin-panel/notifications/notifications.component.ts
+++ b/MyToolsYourToolsClient/src/app/admin-panel/notifications/notifications.component.ts
@@ -35,6 +35,10 @@ export class NotificationsComponent implements OnInit {
 
   ngOnInit() {
     this.currentUserId = localStorage.getItem('auth_key');
+    this.getUserNotifications();
+  }
+
+  getUserNotifications() {
     this.notificationService.getUserNotifications(this.currentUserId)
       .subscribe(n => {
         this.rentRequests = n.filter(not => not.type === NotificationType.rentRequest);
@@ -61,12 +65,13 @@ export class NotificationsComponent implements OnInit {
   }
 
   deleteNotification(notification: Notification) {
-    if (notification.type === NotificationType.rentRequest) {
+    /*if (notification.type === NotificationType.rentRequest) {
       this.rentRequests = this.rentRequests.filter(n => n.id !== notification.id);
     } else if (notification.type === NotificationType.opinion) {
       this.opinions = this.opinions.filter(n => n.id !== notification.id);
-    }
-    this.notificationService.deleteNotification(notification.id).subscribe();
+    }*/
+    this.notificationService.deleteNotification(notification.id)
+    .subscribe(_ => this.getUserNotifications());
   }
 
   onOpinionSent(requestId: any){

--- a/MyToolsYourToolsClient/src/app/admin-panel/notifications/notifications.component.ts
+++ b/MyToolsYourToolsClient/src/app/admin-panel/notifications/notifications.component.ts
@@ -4,6 +4,9 @@ import { NotificationType } from '../../enums/NotificationType';
 import { NotificationService } from '../../services/notification.service';
 import { Opinion } from '../../models/Opinion';
 import { OpinionService } from '../../services/opinion.service';
+import { RentService } from '../../services/rent.service';
+import { Rent } from '../../models/Rent';
+import { AlertService } from '../../services/alert.service';
 
 
 @Component({
@@ -13,7 +16,7 @@ import { OpinionService } from '../../services/opinion.service';
 })
 export class NotificationsComponent implements OnInit {
 
- 
+
   inputText = {};
 
 
@@ -25,8 +28,9 @@ export class NotificationsComponent implements OnInit {
 
   constructor(
     private notificationService: NotificationService,
-    private opinionService:  OpinionService
-
+    private opinionService:  OpinionService,
+    private rentService: RentService,
+    private alertService: AlertService
   ) { }
 
   ngOnInit() {
@@ -37,14 +41,34 @@ export class NotificationsComponent implements OnInit {
         this.opinions = n.filter(not => not.type === NotificationType.opinion);
       });
   }
-  onRequestNotificationApproved(requestId: any){
-    this.rentRequests = this.rentRequests.filter(n => n.id !== requestId);
-    this.notificationService.deleteNotification(requestId).subscribe();
+  onRequestNotificationApproved(rentRequest: Notification){
+    const rentToSend = new Rent(rentRequest.offerId, rentRequest.targetUserId);
+    this.rentService.addRent(rentToSend).subscribe(
+      result => {
+        this.alertService.success('Przedmiot oferty został pomyślnie udostępniony');
+        this.deleteNotification(rentRequest);
+      },
+      error => {
+        this.alertService.error(error.error);
+        console.log(error);
+      }
+    );
+
   }
-  onRequestNotificationRejected(requestId: any){
-    this.rentRequests = this.rentRequests.filter(n => n.id !== requestId);
-    this.notificationService.deleteNotification(requestId).subscribe();
+  onRequestNotificationRejected(rentRequest: Notification){
+    this.alertService.info('Prośba o udostępnienie została odrzucona');
+    this.deleteNotification(rentRequest);
   }
+
+  deleteNotification(notification: Notification) {
+    if (notification.type === NotificationType.rentRequest) {
+      this.rentRequests = this.rentRequests.filter(n => n.id !== notification.id);
+    } else if (notification.type === NotificationType.opinion) {
+      this.opinions = this.opinions.filter(n => n.id !== notification.id);
+    }
+    this.notificationService.deleteNotification(notification.id).subscribe();
+  }
+
   onOpinionSent(requestId: any){
     console.log(this.inputText[requestId]);
     let currentRequest: Notification = this.opinions.find(r=>r.id===requestId);
@@ -53,9 +77,7 @@ export class NotificationsComponent implements OnInit {
       message: this.inputText[requestId],
       ratedUserId: currentRequest.targetUserId,
       ratingUserId: currentRequest.ownerId
-  } 
-  
-  
+  }
     this.opinionService.addOpinion(tmpOpinion).subscribe();
     this.opinions = this.opinions.filter(n => n.id !== requestId);
     this.notificationService.deleteNotification(requestId).subscribe();

--- a/MyToolsYourToolsClient/src/app/models/NotificationForCreation.ts
+++ b/MyToolsYourToolsClient/src/app/models/NotificationForCreation.ts
@@ -1,0 +1,8 @@
+import { NotificationType } from '../enums/NotificationType';
+
+export class NotificationForCreation {
+  ownerId: string;
+  targetUserId: string;
+  offerId: string;
+  type: NotificationType;
+}

--- a/MyToolsYourToolsClient/src/app/models/Rent.ts
+++ b/MyToolsYourToolsClient/src/app/models/Rent.ts
@@ -2,4 +2,9 @@
 export class Rent {
     offerId: string;
     borrowerId: string;
+
+    constructor(offerId: string, borrowerId: string) {
+      this.offerId = offerId;
+      this.borrowerId = borrowerId;
+    }
   }

--- a/MyToolsYourToolsClient/src/app/models/Rent.ts
+++ b/MyToolsYourToolsClient/src/app/models/Rent.ts
@@ -1,6 +1,5 @@
 
 export class Rent {
-    id: string;
     offerId: string;
     borrowerId: string;
   }

--- a/MyToolsYourToolsClient/src/app/navbar/navbar.component.ts
+++ b/MyToolsYourToolsClient/src/app/navbar/navbar.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnChanges } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../services/auth.service';
 import { Router } from '@angular/router';
 import { GroupService } from '../services/group.service';
@@ -6,7 +6,6 @@ import { AlertService } from '../services/alert.service';
 import { tap } from 'rxjs/operators';
 import { User } from '../models/User';
 import { UserService } from '../services/user.service';
-import { Subscription } from 'rxjs';
 
 @Component({
   selector: 'app-navbar',
@@ -31,6 +30,7 @@ export class NavbarComponent implements OnInit {
       this.authService.getCurrentUser().subscribe(u => this.currentUser = u);
     });
   }
+
   logout() {
     this.authService.setCurrentUserToNull();
     localStorage.removeItem('auth_key');

--- a/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.html
+++ b/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.html
@@ -17,7 +17,8 @@
   </div>
   <hr class="mb-4" />
   <div *ngIf="!isMyOffer()" name="notMyOffer">
-    <button class="btn btn-outline-success btn-lg btn-block my-2 my-sm-0" (click)="sendRentRequest()">
+    <button class="btn btn-outline-success btn-lg btn-block my-2 my-sm-0" (click)="sendRentRequest()"
+      [disabled]="alreadySendRentRequest"> <!-- Dodać wycofainie prośby o wypożyczenie -->
       Złóż prośbę o wypożyczenie
     </button>
   </div>

--- a/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.html
+++ b/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.html
@@ -1,5 +1,5 @@
 <div class="container">
-  
+
   <span class="offer-header">{{ offer.tool }}</span>
   <img class="offer-image" src="{{ offer.imageSource }}" />
 
@@ -17,13 +17,13 @@
   </div>
   <hr class="mb-4" />
   <div *ngIf="!isMyOffer()" name="notMyOffer">
-    <button class="btn btn-outline-success btn-lg btn-block my-2 my-sm-0" (click)="sendRentRequest($event, offer.ownerId, offer.id)">
+    <button class="btn btn-outline-success btn-lg btn-block my-2 my-sm-0" (click)="sendRentRequest()">
       Złóż prośbę o wypożyczenie
     </button>
   </div>
   <div *ngIf="isMyOffer()" name="myOffer" class="row">
     <div class="col">
-      <button class="btn btn-outline-success btn-lg" (click)="sendConfirmReturn($event, offer.ownerId, offer.id)"
+      <button class="btn btn-outline-success btn-lg" (click)="sendConfirmReturn()"
         [disabled]="!hasMyOfferBorrowedStatus()">
         Potwierdź zwrot
       </button>

--- a/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.html
+++ b/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.html
@@ -19,7 +19,7 @@
   <div *ngIf="!isMyOffer()" name="notMyOffer">
     <button class="btn btn-outline-success btn-lg btn-block my-2 my-sm-0" (click)="sendRentRequest()"
       [disabled]="alreadySendRentRequest"> <!-- Dodać wycofainie prośby o wypożyczenie -->
-      Złóż prośbę o wypożyczenie
+      {{ alreadySendRentRequest ? "Prośba o wypożyczenie została wysłana" : "Złóż prośbę o wypożyczenie" }}
     </button>
   </div>
   <div *ngIf="isMyOffer()" name="myOffer" class="row">

--- a/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.ts
+++ b/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.ts
@@ -145,7 +145,7 @@ export class OfferViewComponent implements OnInit {
         };
         this.notificationService.addNotification(notificationToSend).subscribe();
         this.alertService.success('Potwierdzono zwrot przedmiotu oferty');
-        this.offer.status = OfferStatus.active;
+        this.getOffer(result.offerId); // refresh offer view
       },
       error => {
         this.alertService.error(error.error);

--- a/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.ts
+++ b/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.ts
@@ -140,6 +140,7 @@ export class OfferViewComponent implements OnInit {
         };
         this.notificationService.addNotification(notificationToSend).subscribe();
         this.alertService.success('Pomyślnie zmieniono status oferty');
+        this.offer.status = OfferStatus.active;
       },
       error => {
         this.alertService.error(error.error);

--- a/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.ts
+++ b/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.ts
@@ -28,6 +28,8 @@ export class OfferViewComponent implements OnInit {
   users: User[];
   groups: Group[];
 
+  alreadySendRentRequest: boolean;
+
   constructor(
     private route: ActivatedRoute,
     private offerService: OfferService,
@@ -54,6 +56,8 @@ export class OfferViewComponent implements OnInit {
     this.offerService.getOffer(id).pipe(
       map(o => this.offer = o),
       tap(_ => {
+        this.notificationService.checkIfUserCanSendRentRequest(this.currentUserId, this.offer.id)
+        .subscribe(canSendRentRequest => this.alreadySendRentRequest = !canSendRentRequest);
       /* tutaj trzeba pobrać nazwę użytkownika i grupy,
        najlepiej przypisane do zmiennych bindowanych w komponencie */
       })
@@ -119,6 +123,7 @@ export class OfferViewComponent implements OnInit {
     this.notificationService.addNotification(notificationToSend).subscribe(
       result => {
         this.alertService.success('Wysłano prośbę o wypożyczenie.');
+        this.alreadySendRentRequest = true;
         // TODO zablokowanie wysłania kolejnej prośby
       },
       error => {
@@ -139,7 +144,7 @@ export class OfferViewComponent implements OnInit {
           type: NotificationType.opinion
         };
         this.notificationService.addNotification(notificationToSend).subscribe();
-        this.alertService.success('Pomyślnie zmieniono status oferty');
+        this.alertService.success('Potwierdzono zwrot przedmiotu oferty');
         this.offer.status = OfferStatus.active;
       },
       error => {

--- a/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.ts
+++ b/MyToolsYourToolsClient/src/app/offer-view/offer-view.component.ts
@@ -8,6 +8,11 @@ import { UserService } from '../services/user.service';
 import { GroupService } from '../services/group.service';
 import { map, tap } from 'rxjs/operators';
 import { OfferStatus } from '../enums/OfferStatus';
+import { AlertService } from '../services/alert.service';
+import { NotificationService } from '../services/notification.service';
+import { NotificationForCreation } from '../models/NotificationForCreation';
+import { NotificationType } from '../enums/NotificationType';
+import { RentService } from '../services/rent.service';
 
 @Component({
   selector: 'app-offer-view',
@@ -23,8 +28,15 @@ export class OfferViewComponent implements OnInit {
   users: User[];
   groups: Group[];
 
-  constructor(private route: ActivatedRoute, private offerService: OfferService, private userService: UserService,
-     private groupService: GroupService) { }
+  constructor(
+    private route: ActivatedRoute,
+    private offerService: OfferService,
+    private userService: UserService,
+    private groupService: GroupService,
+    private alertService: AlertService,
+    private notificationService: NotificationService,
+    private rentService: RentService
+  ) { }
 
   ngOnInit() {
     this.currentUserId = localStorage.getItem('auth_key');
@@ -97,12 +109,43 @@ export class OfferViewComponent implements OnInit {
     return Object.values(OfferStatus)[number];
   }
 
-  sendRentRequest(event, userId, offerId) {
-    // TODO: wysłanie żądania wyporzyczenia
+  sendRentRequest() {
+    const notificationToSend: NotificationForCreation = {
+      ownerId: this.offer.ownerId,
+      targetUserId: this.currentUserId,
+      offerId: this.offer.id,
+      type: NotificationType.rentRequest
+    };
+    this.notificationService.addNotification(notificationToSend).subscribe(
+      result => {
+        this.alertService.success('Wysłano prośbę o wypożyczenie.');
+        // TODO zablokowanie wysłania kolejnej prośby
+      },
+      error => {
+        this.alertService.error(error.error);
+        console.log(error);
+      }
+    );
   }
 
-  sendConfirmReturn(event, userId, offerId) {
-    // TODO: wysłanie potwierdzenia zwrotu
+  sendConfirmReturn() {
+    // TODO: pierw wyświetlenie pop-up z wystawieniem opinii wypożyczającemu inną metodą a na "Wyślij" wykonanie tej
+    this.rentService.deleteRent(this.offer.id).subscribe(
+      result => {
+        const notificationToSend: NotificationForCreation = {
+          ownerId: result.borrowerId,
+          targetUserId: this.currentUserId,
+          offerId: result.offerId,
+          type: NotificationType.opinion
+        };
+        this.notificationService.addNotification(notificationToSend).subscribe();
+        this.alertService.success('Pomyślnie zmieniono status oferty');
+      },
+      error => {
+        this.alertService.error(error.error);
+        console.log(error);
+      }
+    )
   }
 
 }

--- a/MyToolsYourToolsClient/src/app/services/notification.service.ts
+++ b/MyToolsYourToolsClient/src/app/services/notification.service.ts
@@ -3,6 +3,7 @@ import { Notification } from '../models/Notification';
 import { NotificationType } from '../enums/NotificationType';
 import { Observable, of } from 'rxjs';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { NotificationForCreation } from '../models/NotificationForCreation';
 
 const httpOptions = {
   headers: new HttpHeaders({ 'Content-Type': 'application/json' })
@@ -19,11 +20,10 @@ export class NotificationService {
   getUserNotifications(userId: string): Observable<Notification[]> {
    return this.http.get<Notification[]>(this.baseUrl + 'notifications/' + userId, httpOptions);
   }
-  addNotification(notification: Notification) :Observable<Notification>{
-    return this.http.post<Notification>(this.baseUrl+'notifications/',notification,httpOptions);
+  addNotification(notification: NotificationForCreation) :Observable<NotificationForCreation>{
+    return this.http.post<NotificationForCreation>(this.baseUrl+'notifications/',notification,httpOptions);
   }
   deleteNotification(notificationId: string): Observable<{}> {
-    console.log(this.baseUrl+'notifications/'+notificationId);
     return this.http.delete(this.baseUrl+'notifications/'+notificationId,httpOptions);
   }
 }

--- a/MyToolsYourToolsClient/src/app/services/notification.service.ts
+++ b/MyToolsYourToolsClient/src/app/services/notification.service.ts
@@ -26,4 +26,8 @@ export class NotificationService {
   deleteNotification(notificationId: string): Observable<{}> {
     return this.http.delete(this.baseUrl+'notifications/'+notificationId,httpOptions);
   }
+  checkIfUserCanSendRentRequest(userId: string, offerId: string): Observable<boolean> {
+    return this.http.get<boolean>(this.baseUrl + 'notifications/' + userId +
+      '/' +  offerId + '/check-if-can-send-rent-request', httpOptions);
+   }
 }

--- a/MyToolsYourToolsClient/src/app/services/rent.service.ts
+++ b/MyToolsYourToolsClient/src/app/services/rent.service.ts
@@ -1,16 +1,26 @@
 import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Observable } from 'rxjs';
 import { Rent } from '../models/Rent';
 
+const httpOptions = {
+  headers: new HttpHeaders({ 'Content-Type': 'application/json' })
+};
 @Injectable({
   providedIn: 'root',
 })
 export class RentService {
-  rents: Rent[];
+  baseUrl = 'https://localhost:44341/api/';
 
-  constructor() { }
+  constructor(private http: HttpClient) { }
 
-  addRent(rent: Rent) {
-    this.rents.push(rent);
+  addRent (rent: Rent): Observable<Rent> {
+    return this.http.post<Rent>(this.baseUrl + 'rents', rent, httpOptions);
   }
+
+  deleteRent (offerId: string): Observable<any> {
+    return this.http.delete(this.baseUrl + 'rents/' + offerId, httpOptions);
+  }
+
 
 }

--- a/MyToolsYourToolsClient/src/app/services/rent.service.ts
+++ b/MyToolsYourToolsClient/src/app/services/rent.service.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import { tap, catchError } from 'rxjs/operators';
 import { Rent } from '../models/Rent';
+import { AlertService } from './alert.service';
 
 const httpOptions = {
   headers: new HttpHeaders({ 'Content-Type': 'application/json' })
@@ -12,14 +14,14 @@ const httpOptions = {
 export class RentService {
   baseUrl = 'https://localhost:44341/api/';
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient, private alertService: AlertService) { }
 
   addRent (rent: Rent): Observable<Rent> {
-    return this.http.post<Rent>(this.baseUrl + 'rents', rent, httpOptions);
+    return this.http.post<Rent>(this.baseUrl + 'rents', rent, httpOptions)
   }
 
-  deleteRent (offerId: string): Observable<any> {
-    return this.http.delete(this.baseUrl + 'rents/' + offerId, httpOptions);
+  deleteRent (offerId: string): Observable<Rent> {
+    return this.http.delete<Rent>(this.baseUrl + 'rents/' + offerId, httpOptions);
   }
 
 


### PR DESCRIPTION
Mechanizm wypożyczeń w połączeniu z punktami powinien działać ok
Punkty działają tak, że są już pobierane gdy użytkownik wyśle powiadomienie "Prośba o wypożyczenie", jako kaucja. Kaucja jest zwracana w momencie usunięcia powiadomienia z bazy (dla zgody i odrzucenia), ale jak jest zgoda to dodanie wypożyczenia w RentService znowu pobiera punkty, także saldo wychodzi jakie powinno.

Dodałem też coś takiego że jak użytkownik w danym momencie ma kilka powiadomień z próśbą o wypożyczenie dla tej samej oferty, to jak zaakceptuje jedną, pozostałe prośby do tej oferty są automatycznie usuwane (przez co kaucja jest zwracana tym, którzy tej oferty nie dostają)

Potwierdzenie zwrotu też już działa (wysyłane jest powiadomienie o wystawieniu opinii o udostępniającym)

I dodałem też coś takiego, że jak do jakiejś oferty użytkownik wysłał prośbę o wypożyczenie to do momentu zareagowania na to przez właściciela nie może jej wysłać ponownie (taki anty-spam)